### PR TITLE
Potential fix for code scanning alert no. 14: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -2,6 +2,8 @@ name: Nix hash
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
 jobs:
     build:
         runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/FuckingNode/FuckingNode/security/code-scanning/14](https://github.com/FuckingNode/FuckingNode/security/code-scanning/14)

To fix this issue, you should add a `permissions` block to the workflow at the root level (before or after the `on` section). The minimal recommended permissions are `contents: read`, which restricts the GITHUB_TOKEN to read-only access to repository contents. This change should be added at the root of `.github/workflows/nix.yml`, above `jobs:`. No change to existing workflow functionality is necessary. No external libraries or additional steps are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
